### PR TITLE
copy-paste ready code in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -68,6 +68,7 @@ mapdeck (style = 'mapbox://styles/mapbox/dark-v9',
               lon = "x",
               lat = "y",
               radius = 10,
-              fill_colour = "m")
+              fill_colour = "m",
+              palette = "inferno")
 ```
 ![](demo.png)

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,7 @@ that properly just yet, but it will soon enough ...)
 Currently only one function that works like this:
 ```{r, eval = FALSE}
 library (moveability)
-m <- moveability (city = "muenster germany")
+verts <- moveability (city = "muenster germany")
 ```
 The function does a heap of heavy work, downloading the entire street net and
 calculating routes between every single pair of points in the network. This
@@ -59,7 +59,7 @@ walkability. The result can be directly viewed with
 library (mapdeck)
 set_token (Sys.getenv ("MAPBOX_TOKEN"))
 loc <- c (mean (verts$x), mean (verts$y))
-verts$d <- 20 * verts$d / max (verts$d)
+verts$m <- 20 * verts$m / max (verts$m)
 mapdeck (style = 'mapbox://styles/mapbox/dark-v9',
          zoom = 12,
          location = loc) %>%
@@ -68,7 +68,6 @@ mapdeck (style = 'mapbox://styles/mapbox/dark-v9',
               lon = "x",
               lat = "y",
               radius = 10,
-              fill_colour = "d",
-              palette = "inferno")
+              fill_colour = "m")
 ```
 ![](demo.png)


### PR DESCRIPTION
I just fixed some variable names that prevented the code in the README to work.

Also, the `inferno` palette gives this error for me (maybe I'm missing a package?), so I removed it from the command.
```
Fehler in checkPalette(palette) : 
  palette must be a function which generates hex colours
```